### PR TITLE
Sensor reset and int pins

### DIFF
--- a/imag_sensor_feather_m0_bno08x/Adafruit_BNO08x_ext.cpp
+++ b/imag_sensor_feather_m0_bno08x/Adafruit_BNO08x_ext.cpp
@@ -8,6 +8,10 @@
 
 #include "Adafruit_BNO08x_ext.h"
 
+Adafruit_BNO08x_ext::Adafruit_BNO08x_ext (int8_t reset_pin)
+  : Adafruit_BNO08x (reset_pin)
+{}
+
 bool Adafruit_BNO08x_ext::softwareReset()
 {
   return sh2_reinitialize() == SH2_OK;   

--- a/imag_sensor_feather_m0_bno08x/Adafruit_BNO08x_ext.cpp
+++ b/imag_sensor_feather_m0_bno08x/Adafruit_BNO08x_ext.cpp
@@ -48,9 +48,7 @@ bool Adafruit_BNO08x_ext::setSensorsPerformingDynamicCalibration (uint8_t sensor
 }
 
 
-uint8_t Adafruit_BNO08x_ext::getSensorsPerformingDynamicCalibration()
+bool Adafruit_BNO08x_ext::getSensorsPerformingDynamicCalibration (uint8_t& sensors)
 {
-  uint8_t sensors;
-
-  return sh2_getCalConfig (&sensors) == SH2_OK ? sensors : 0;
+  return sh2_getCalConfig (&sensors) == SH2_OK;
 }

--- a/imag_sensor_feather_m0_bno08x/Adafruit_BNO08x_ext.h
+++ b/imag_sensor_feather_m0_bno08x/Adafruit_BNO08x_ext.h
@@ -12,7 +12,9 @@
 
 class Adafruit_BNO08x_ext : public Adafruit_BNO08x
 {
-  public:  
+  public:
+    Adafruit_BNO08x_ext (int8_t reset_pin = -1);
+
     bool softwareReset();
 
     bool setTare (uint8_t axes, sh2_TareBasis_t basis);

--- a/imag_sensor_feather_m0_bno08x/Adafruit_BNO08x_ext.h
+++ b/imag_sensor_feather_m0_bno08x/Adafruit_BNO08x_ext.h
@@ -27,7 +27,6 @@ class Adafruit_BNO08x_ext : public Adafruit_BNO08x
     
     bool setSensorsPerformingDynamicCalibration (uint8_t sensors);
 
-    uint8_t getSensorsPerformingDynamicCalibration();
-
+    bool getSensorsPerformingDynamicCalibration (uint8_t& sensors);
 
 }; // class Adafruit_BNO08x_ext

--- a/imag_sensor_feather_m0_bno08x/imag_config.h
+++ b/imag_sensor_feather_m0_bno08x/imag_config.h
@@ -47,6 +47,10 @@ namespace Config
   // default wifi ap ssid and key
   static constexpr auto wifiSSID = "imagination";
   static constexpr auto wifiPASS = "atmospheres";
+
+  // bno08x pins
+  static constexpr auto bno08x_int_pin = 11;
+  static constexpr auto bno08x_reset_pin = 12;
 }
 }
 

--- a/imag_sensor_feather_m0_bno08x/imag_debug.h
+++ b/imag_sensor_feather_m0_bno08x/imag_debug.h
@@ -15,12 +15,16 @@
 
 // debug print to serial
 #if IMAG_DEBUG
-#define DBG(DATA)    Serial.print (DATA)
-#define DBGLN(DATA)  Serial.println (DATA)
-#define DBGHEX(DATA) Serial.print (DATA, HEX)
+#define DBG(STR)     Serial.print (F(STR))
+#define DBGLN(STR)   Serial.println (F(STR))
+#define DBGN(VAR)    Serial.print (VAR)
+#define DBGNLN(VAR)  Serial.println (VAR)
+#define DBGHEX(NUM)  Serial.print (NUM, HEX)
 #else
 #define DBG          ;
 #define DBGLN        ;
+#define DBGN         ;
+#define DBGNLN       ;
 #define DBGHEX       ;
 #endif // IMAG_DEBUG
 

--- a/imag_sensor_feather_m0_bno08x/imag_imu_bno08x.cpp
+++ b/imag_sensor_feather_m0_bno08x/imag_imu_bno08x.cpp
@@ -217,9 +217,9 @@ void Imu_BNO08x::printCalibrationReliability()
 bool Imu_BNO08x::printSensorsPerformingDynamicCalibration()
 {
 #if IMAG_IMU_DEBUG
-  auto sensors = bno08x.getSensorsPerformingDynamicCalibration();
+  uint8_t sensors;
 
-  if (! sensors)
+  if (! bno08x.getSensorsPerformingDynamicCalibration(sensors))
   {
     DBGLN("Imu_BNO08x: querying sensor dynamic calibration state failed");
     return false;

--- a/imag_sensor_feather_m0_bno08x/imag_imu_bno08x.cpp
+++ b/imag_sensor_feather_m0_bno08x/imag_imu_bno08x.cpp
@@ -9,10 +9,18 @@
 #include "imag_imu_bno08x.h"
 #include "imag_config.h"
 
+// redefine DBG output macros for this module only
 #if ! IMAG_IMU_DEBUG
-#define DBG          ;
-#define DBGLN        ;
-#define DBGHEX       ;
+#undef DBG
+#define DBG       ;
+#undef DBGLN
+#define DBGLN     ;
+#undef DBGN
+#define DBGN      ;
+#undef DBGNLN
+#define DBGNLN    ;
+#undef DBGHEX
+#define DBGHEX    ;
 #endif // #if ! IMAG_IMU_DEBUG
 
 using namespace Imag;

--- a/imag_sensor_feather_m0_bno08x/imag_imu_bno08x.cpp
+++ b/imag_sensor_feather_m0_bno08x/imag_imu_bno08x.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "imag_imu_bno08x.h"
+#include "imag_config.h"
 
 #if ! IMAG_IMU_DEBUG
 #define DBG          ;
@@ -39,12 +40,16 @@ const std::array<int, static_cast<int> (Imu::DataType::total_num)> Imu_BNO08x::d
 
 
 Imu_BNO08x::Imu_BNO08x()
-  : reliability (0),
+  : bno08x (Config::bno08x_reset_pin),
+    reliability (0),
     accuracy (-1.0f),
     sourceOfReliability (DataType::none),
     sourceOfAccuracy (DataType::none),
     calibrating (false)
 {
+  // interrupt pin, only configure for now (unused)
+  pinMode (Config::bno08x_int_pin, INPUT_PULLUP);
+
   queryRates.fill (100); // default
 }
 

--- a/imag_sensor_feather_m0_bno08x/imag_imu_bno08x.h
+++ b/imag_sensor_feather_m0_bno08x/imag_imu_bno08x.h
@@ -60,7 +60,7 @@ private:
 
   // quaternion translation helpers
   static sh2_Quaternion_t quatToSh2Quat (const Quaternion& quat) { return { quat.x, quat.y, quat.z, quat.w }; }
-  static Quaternion sh2QuatToQuat (const sh2_Quaternion_t& sh2Quat) { return { sh2Quat.w, sh2Quat.x, sh2Quat.y, sh2Quat.z }; }
+  static Quaternion sh2QuatToQuat (const sh2_Quaternion_t& sh2Quat) { return { float (sh2Quat.w), float (sh2Quat.x), float (sh2Quat.y), float (sh2Quat.z) }; }
 
   // bno08x interface object
   Adafruit_BNO08x_ext bno08x;

--- a/imag_sensor_feather_m0_bno08x/imag_net_winc150x.cpp
+++ b/imag_sensor_feather_m0_bno08x/imag_net_winc150x.cpp
@@ -8,10 +8,18 @@
 
 #include "imag_net_winc150x.h"
 
+// redefine DBG output macros for this module only
 #if ! IMAG_NET_DEBUG
-#define DBG          ;
-#define DBGLN        ;
-#define DBGHEX       ;
+#undef DBG
+#define DBG       ;
+#undef DBGLN
+#define DBGLN     ;
+#undef DBGN
+#define DBGN      ;
+#undef DBGNLN
+#define DBGNLN    ;
+#undef DBGHEX
+#define DBGHEX    ;
 #endif // #if ! IMAG_NET_DEBUG
 
 using namespace Imag;

--- a/imag_sensor_feather_m0_bno08x/imag_sensor_feather_m0_bno08x.ino
+++ b/imag_sensor_feather_m0_bno08x/imag_sensor_feather_m0_bno08x.ino
@@ -207,9 +207,9 @@ void setup()
   // init debug serial console in case debugging is enabled
   Imag::Debug::init();
   DBG("Imagination sensor version ");
-  DBG(Imag::Config::versionMajor); DBG(".");
-  DBG(Imag::Config::versionMinor); DBG(".");
-  DBGLN(Imag::Config::versionSub);
+  DBGN(Imag::Config::versionMajor); DBG(".");
+  DBGN(Imag::Config::versionMinor); DBG(".");
+  DBGNLN(Imag::Config::versionSub);
 
   // init sensor
   if (! imu.init())
@@ -397,14 +397,14 @@ void loop()
     battery *= 2.0f;    // we divided by 2, so multiply back
     battery *= 3.3f;  // Multiply by 3.3V, our reference voltage
     battery /= 1024.0f; // convert to voltage
-    DBG("Battery: "); DBGLN(battery);
+    DBG("Battery: "); DBGNLN(battery);
 
     // calculate effective reliability/accuracy to display
     auto rel = reliabilitySum / smoothLen;
     auto acc =  constrain ((accuracySum / smoothLen) * 180.0 / PI, 0.0, 23.0);
 
-    DBG("smoothed reliability: "); DBGLN(rel);
-    DBG("smoothed accuracy: "); DBGLN(acc);
+    DBG("smoothed reliability: "); DBGNLN(rel);
+    DBG("smoothed accuracy: "); DBGNLN(acc);
 
     // display
     display.clearDisplay();
@@ -443,7 +443,7 @@ void loop()
 
   if (dataReceived)
     DBG("data received. ");
-  DBG("loop took [ms]: "); DBGLN(elapsed);
+  DBG("loop took [ms]: "); DBGNLN(elapsed);
 
   if (dataReceived && elapsed < 10)
   {

--- a/imag_sensor_feather_m0_bno08x/imag_sensor_feather_m0_bno08x.ino
+++ b/imag_sensor_feather_m0_bno08x/imag_sensor_feather_m0_bno08x.ino
@@ -13,7 +13,8 @@
 
 #include <MIDIUSB.h>
 
-#include <Adafruit_SSD1306.h>
+#include <Adafruit_SSD1306.h> // 128x32 oled display
+#include <Adafruit_SH110X.h>  // 128x64 oled display
 #include <EasyButton.h>
 
 // #include <ArduinoLowPower.h>
@@ -29,7 +30,8 @@
 // member data
 Imag::Imu_BNO08x imu;
 Imag::Net_WINC150x net;
-Adafruit_SSD1306 display { 128, 32, &Wire };   // oled display
+Adafruit_SSD1306 display { 128, 32, &Wire };  // oled display 128x32
+//Adafruit_SH1107 display { 64, 128, &Wire };   // oled display 128x64
 
 EasyButton displayButton(BUTTON_A, 35, true, true);
 EasyButton tareButton(BUTTON_B, 35, true, true);
@@ -174,11 +176,20 @@ void setup()
   digitalWrite (LED_BUILTIN, LOW);
 
   // init display: cleanup/separate!
+  // 128x32
   // SSD1306_SWITCHCAPVCC = generate display voltage from 3.3V internally
-  display.begin(SSD1306_SWITCHCAPVCC, 0x3C); // Address 0x3C for 128x32
+  display.begin(SSD1306_SWITCHCAPVCC, 0x3C);
   display.dim(true);
-  display.clearDisplay();
   display.setTextColor(SSD1306_WHITE);
+
+  // 128x64
+  /*
+  display.begin(0x3C, true);
+  display.setRotation(1);
+  display.setTextColor(SH110X_WHITE);
+  */
+
+  display.clearDisplay();
   display.setCursor (0, 0);
   display.setTextSize(2);
   display.println("ImagSens");

--- a/imag_sensor_feather_m0_bno08x/imag_sensor_feather_m0_bno08x.ino
+++ b/imag_sensor_feather_m0_bno08x/imag_sensor_feather_m0_bno08x.ino
@@ -65,7 +65,7 @@ int orientationMode = 0;
 
 // custom north offset
 bool customNorth = false;
-Quaternion customNorthOffset;
+Quaternion customNorthOffset = Quaternion::identity();
 
 // reliability && accuracy smoothing buffers
 static constexpr auto smoothLen = 100;
@@ -171,6 +171,8 @@ void resetTare()
 
 void setup()
 {
+  delay (500); // give the baby some time to settle
+
   // led
   pinMode (LED_BUILTIN, OUTPUT);
   digitalWrite (LED_BUILTIN, LOW);
@@ -178,9 +180,10 @@ void setup()
   // init display: cleanup/separate!
   // 128x32
   // SSD1306_SWITCHCAPVCC = generate display voltage from 3.3V internally
-  display.begin(SSD1306_SWITCHCAPVCC, 0x3C);
-  display.dim(true);
-  display.setTextColor(SSD1306_WHITE);
+  display.begin (SSD1306_SWITCHCAPVCC, 0x3C);
+  delay (100);
+  display.dim (true);
+  display.setTextColor (SSD1306_WHITE);
 
   // 128x64
   /*
@@ -188,18 +191,17 @@ void setup()
   display.setRotation(1);
   display.setTextColor(SH110X_WHITE);
   */
-
   display.clearDisplay();
   display.setCursor (0, 0);
-  display.setTextSize(2);
-  display.println("ImagSens");
-  display.setTextSize(1);
+  display.setTextSize (2);
+  display.println ("ImagSens");
+  display.setTextSize (1);
   display.println();
 
 #if IMAG_DEBUG
-  display.println("Waiting for serial...");
+  display.println ("Waiting for serial...");
 #else
-  display.println("Initialising...");
+  display.println ("Initialising...");
 #endif // IMAG_DEBUG
 
   display.display();


### PR DESCRIPTION
This enables the wired hardware reset pin of the sensor on newer imagination sensor firmware versions and improves startup and reset behaviour.
